### PR TITLE
feat: tls access relation

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         arch:
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: [self-hosted, linux, X64, jammy, xlarge]
   
     runs-on: ${{ matrix.arch.runner }}
     steps:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -31,6 +31,9 @@ provides:
     interface: grafana_dashboard
 
 requires:
+  access-certificates:
+    limit: 1
+    interface: tls-certificates
   logging:
     interface: loki_push_api
 

--- a/src/notary.py
+++ b/src/notary.py
@@ -56,6 +56,7 @@ class Notary:
                 json={"username": username, "password": password},
             )
         except (requests.RequestException, OSError):
+            logger.warning("login failed: ", exc_info=True)
             return
         try:
             req.raise_for_status()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -129,7 +129,7 @@ async def test_given_notary_when_tls_requirer_related_then_csr_uploaded_to_notar
     await ops_test.model.integrate(
         relation1=f"{APP_NAME}:certificates",
         relation2=f"{TLS_REQUIRER_APPLICATION_NAME}",
-    )  # type: ignore
+    )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, TLS_REQUIRER_APPLICATION_NAME],
         status="active",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,9 +16,9 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     generate_certificate,
     generate_private_key,
 )
+from juju.application import Application
 from juju.client.client import SecretsFilter
 from pytest_operator.plugin import OpsTest
-from juju.application import Application
 
 from charm import NOTARY_LOGIN_SECRET_LABEL
 from notary import Notary

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import tempfile
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import ops
@@ -9,7 +10,12 @@ import pytest
 from ops.pebble import Layer
 from scenario import Container, Context, Mount, Network, Relation, Secret, State, Storage
 
-from charm import CERTIFICATE_PROVIDER_RELATION_NAME, NOTARY_LOGIN_SECRET_LABEL, NotaryCharm
+from charm import (
+    CERTIFICATE_PROVIDER_RELATION_NAME,
+    NOTARY_LOGIN_SECRET_LABEL,
+    TLS_ACCESS_RELATION_NAME,
+    NotaryCharm,
+)
 from lib.charms.tls_certificates_interface.v4.tls_certificates import (
     Certificate,
     PrivateKey,
@@ -20,12 +26,15 @@ from lib.charms.tls_certificates_interface.v4.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from notary import CertificateRequest, CertificateRequests
+from notary import CertificateRequest as CertificateRequestRow
+from notary import CertificateRequests
 
 TLS_LIB_PATH = "charms.tls_certificates_interface.v4.tls_certificates"
 
 CERTIFICATE_COMMON_NAME = "Notary Self Signed Certificate"
 SELF_SIGNED_CA_COMMON_NAME = "Notary Self Signed Root CA"
+
+TLS_LIB_PATH = "charms.tls_certificates_interface.v4.tls_certificates"
 
 
 class TestCharm:
@@ -289,9 +298,7 @@ class TestCharm:
             out = context.run(context.on.config_changed(), state)
         root = out.get_container("notary").get_filesystem(context)
         assert (root / "etc/notary/config/config.yaml").open("r")
-        assert not (root / "etc/notary/config/certificate.pem").exists()
-        assert not (root / "etc/notary/config/private_key.pem").exists()
-        assert len(out.secrets) == 1
+        assert len(list(out.secrets)) == 1
         assert out.get_secret(label="Notary Login Details")
 
     def test_given_only_config_storage_container_cant_connect_network_available_notary_not_running_when_configure_then_no_error_raised(
@@ -777,9 +784,7 @@ class TestCharm:
             out = context.run(context.on.config_changed(), state)
         root = out.get_container("notary").get_filesystem(context)
         assert (root / "etc/notary/config/config.yaml").open("r")
-        assert not (root / "etc/notary/config/certificate.pem").exists()
-        assert not ((root / "etc/notary/config/private_key.pem").exists())
-        assert len(out.secrets) == 1
+        assert len(list(out.secrets)) == 1
         assert out.get_secret(label="Notary Login Details")
 
     def test_given_only_config_storage_container_cant_connect_network_available_notary_running_when_configure_then_no_error_raised(
@@ -1252,9 +1257,7 @@ class TestCharm:
 
         root = out.get_container("notary").get_filesystem(context)
         assert (root / "etc/notary/config/config.yaml").open("r")
-        assert not (root / "etc/notary/config/certificate.pem").exists()
-        assert not ((root / "etc/notary/config/private_key.pem").exists())
-        assert len(out.secrets) == 1
+        assert len(list(out.secrets)) == 1
         assert out.get_secret(label="Notary Login Details")
 
     def test_given_only_config_storage_container_cant_connect_network_available_notary_initialized_when_configure_then_no_error_raised(
@@ -1732,7 +1735,7 @@ class TestCharm:
             ),
         ):
             out = context.run(context.on.collect_unit_status(), state)
-        assert out.unit_status == ops.WaitingStatus("certificates not yet created")
+        assert out.unit_status == ops.WaitingStatus("certificates not yet pushed to workload")
 
     def test_given_only_config_storage_container_cant_connect_network_available_notary_not_running_when_collect_status_then_status_is_waiting(
         self, context
@@ -1972,7 +1975,7 @@ class TestCharm:
             ),
         ):
             out = context.run(context.on.collect_unit_status(), state)
-        assert out.unit_status == ops.WaitingStatus("certificates not yet created")
+        assert out.unit_status == ops.WaitingStatus("certificates not yet pushed to workload")
 
     def test_given_only_config_storage_container_cant_connect_network_not_available_notary_running_when_collect_status_then_status_is_waiting(
         self, context
@@ -2212,7 +2215,7 @@ class TestCharm:
             ),
         ):
             out = context.run(context.on.collect_unit_status(), state)
-        assert out.unit_status == ops.WaitingStatus("certificates not yet created")
+        assert out.unit_status == ops.WaitingStatus("certificates not yet pushed to workload")
 
     def test_given_only_config_storage_container_cant_connect_network_available_notary_running_when_collect_status_then_status_is_waiting(
         self, context
@@ -2452,7 +2455,7 @@ class TestCharm:
             ),
         ):
             out = context.run(context.on.collect_unit_status(), state)
-        assert out.unit_status == ops.WaitingStatus("certificates not yet created")
+        assert out.unit_status == ops.WaitingStatus("certificates not yet pushed to workload")
 
     def test_given_only_config_storage_container_cant_connect_network_not_available_notary_initialized_when_collect_status_then_status_is_waiting(
         self, context
@@ -2692,7 +2695,7 @@ class TestCharm:
             ),
         ):
             out = context.run(context.on.collect_unit_status(), state)
-        assert out.unit_status == ops.WaitingStatus("certificates not yet created")
+        assert out.unit_status == ops.WaitingStatus("certificates not yet pushed to workload")
 
     def test_given_only_config_storage_container_cant_connect_network_available_notary_initialized_when_collect_status_then_status_is_waiting(
         self, context
@@ -2932,7 +2935,7 @@ class TestCharm:
             ),
         ):
             out = context.run(context.on.collect_unit_status(), state)
-        assert out.unit_status == ops.WaitingStatus("certificates not yet created")
+        assert out.unit_status == ops.WaitingStatus("certificates not yet pushed to workload")
 
     def test_given_notary_available_and_initialized_when_collect_status_then_status_is_active(
         self, context
@@ -2944,7 +2947,6 @@ class TestCharm:
                 containers=[
                     Container(name="notary", can_connect=True, mounts={"config": config_mount})
                 ],
-                networks={Network("juju-info")},
                 leader=True,
             )
 
@@ -2969,9 +2971,28 @@ class TestCharm:
             state = State(
                 storages={Storage(name="config"), Storage(name="database")},
                 containers=[
-                    Container(name="notary", can_connect=True, mounts={"config": config_mount})
+                    Container(
+                        name="notary",
+                        can_connect=True,
+                        mounts={"config": config_mount},
+                        layers={
+                            "notary": Layer(
+                                {
+                                    "summary": "notary layer",
+                                    "description": "pebble config layer for notary",
+                                    "services": {
+                                        "notary": {
+                                            "override": "replace",
+                                            "summary": "notary",
+                                            "command": "notary -config /etc/notary/config/config.yaml",
+                                            "startup": "enabled",
+                                        }
+                                    },
+                                }
+                            )
+                        },
+                    )
                 ],
-                networks={Network("juju-info")},
                 leader=True,
             )
 
@@ -2987,8 +3008,9 @@ class TestCharm:
                 ),
             ):
                 out = context.run(context.on.update_status(), state)
-            assert len(out.secrets) == 1
+            assert len(list(out.secrets)) == 1
             secret = out.get_secret(label="Notary Login Details")
+            assert secret.latest_content
             assert secret.latest_content.get("token") == "example-token"
 
     def test_given_tls_requirer_available_when_notary_unreachable_then_no_error_raised(
@@ -3155,7 +3177,7 @@ class TestCharm:
                     "is_initialized.return_value": True,
                     "token_is_valid.return_value": True,
                     "get_certificate_requests_table.return_value": CertificateRequests(
-                        rows=[CertificateRequest(id=1, csr=str(csr), certificate_chain="")]
+                        rows=[CertificateRequestRow(id=1, csr=str(csr), certificate_chain="")]
                     ),
                     "post_csr": post_call,
                 },
@@ -3225,7 +3247,7 @@ class TestCharm:
                     "token_is_valid.return_value": True,
                     "get_certificate_requests_table.return_value": CertificateRequests(
                         rows=[
-                            CertificateRequest(
+                            CertificateRequestRow(
                                 id=1, csr=str(csr), certificate_chain=[str(cert), str(ca)]
                             )
                         ]
@@ -3311,7 +3333,7 @@ class TestCharm:
                     "token_is_valid.return_value": True,
                     "get_certificate_requests_table.return_value": CertificateRequests(
                         rows=[
-                            CertificateRequest(
+                            CertificateRequestRow(
                                 id=1, csr=str(csr), certificate_chain=[str(new_cert), str(ca)]
                             )
                         ]
@@ -3395,10 +3417,180 @@ class TestCharm:
                     "is_initialized.return_value": True,
                     "token_is_valid.return_value": True,
                     "get_certificate_requests_table.return_value": CertificateRequests(
-                        rows=[CertificateRequest(id=1, csr=str(csr), certificate_chain="rejected")]
+                        rows=[
+                            CertificateRequestRow(id=1, csr=str(csr), certificate_chain="rejected")
+                        ]
                     ),
                 },
             ),
         ):
             context.run(context.on.update_status(), state)
         mock_set_relation_certificate.assert_called_once()
+
+    @patch(f"{TLS_LIB_PATH}.TLSCertificatesRequiresV4.get_assigned_certificate")
+    def test_given_access_relation_created_when_configure_then_certificate_not_replaced(
+        self, mock_assigned_certificates, context
+    ):
+        with tempfile.TemporaryDirectory() as tempdir:
+            config_mount = Mount(location="/etc/notary/config", source=tempdir)
+            state = State(
+                storages={Storage(name="config"), Storage(name="database")},
+                containers=[
+                    Container(
+                        name="notary",
+                        can_connect=True,
+                        mounts={"config": config_mount},
+                        layers={
+                            "notary": Layer(
+                                {
+                                    "summary": "notary layer",
+                                    "description": "pebble config layer for notary",
+                                    "services": {
+                                        "notary": {
+                                            "override": "replace",
+                                            "summary": "notary",
+                                            "command": "notary -config /etc/notary/config/config.yaml",
+                                            "startup": "enabled",
+                                        }
+                                    },
+                                }
+                            )
+                        },
+                    )
+                ],
+                relations=[Relation(id=1, endpoint=TLS_ACCESS_RELATION_NAME)],
+                leader=True,
+            )
+            certificate, _ = self.example_cert_and_key()
+            with open(tempdir + "/certificate.pem", "w") as f:
+                f.write(str(certificate))
+            mock_assigned_certificates.return_value = (None, None)
+            with patch(
+                "notary.Notary.__new__",
+                return_value=Mock(
+                    **{
+                        "is_api_available.return_value": True,
+                        "is_initialized.return_value": True,
+                        "login.return_value": "example-token",
+                        "token_is_valid.return_value": True,
+                    },
+                ),
+            ):
+                context.run(context.on.update_status(), state)
+            Path(tempdir + "etc/notary/config").mkdir(parents=True, exist_ok=True)
+            with open(tempdir + "/certificate.pem") as f:
+                saved_cert = f.read()
+                assert saved_cert == str(certificate)
+
+    @patch(f"{TLS_LIB_PATH}.TLSCertificatesRequiresV4.get_assigned_certificate")
+    def test_given_new_certificate_available_when_configure_then_certificate_replaced(
+        self, mock_assigned_certificates, context
+    ):
+        with tempfile.TemporaryDirectory() as tempdir:
+            config_mount = Mount(location="/etc/notary/config", source=tempdir)
+            state = State(
+                storages={Storage(name="config"), Storage(name="database")},
+                containers=[
+                    Container(
+                        name="notary",
+                        can_connect=True,
+                        mounts={"config": config_mount},
+                        layers={
+                            "notary": Layer(
+                                {
+                                    "summary": "notary layer",
+                                    "description": "pebble config layer for notary",
+                                    "services": {
+                                        "notary": {
+                                            "override": "replace",
+                                            "summary": "notary",
+                                            "command": "notary -config /etc/notary/config/config.yaml",
+                                            "startup": "enabled",
+                                        }
+                                    },
+                                }
+                            )
+                        },
+                    )
+                ],
+                relations=[Relation(id=1, endpoint=TLS_ACCESS_RELATION_NAME)],
+                leader=True,
+            )
+            existing_certificate, _ = self.example_cert_and_key()
+            certificate, pk = self.example_cert_and_key()
+            provider_certificate_mock = Mock()
+            provider_certificate_mock.certificate = certificate.raw
+            with open(tempdir + "/certificate.pem", "w") as f:
+                f.write(str(existing_certificate))
+            mock_assigned_certificates.return_value = (provider_certificate_mock, pk)
+            with patch(
+                "notary.Notary.__new__",
+                return_value=Mock(
+                    **{
+                        "is_api_available.return_value": True,
+                        "is_initialized.return_value": True,
+                        "login.return_value": "example-token",
+                        "token_is_valid.return_value": True,
+                    },
+                ),
+            ):
+                context.run(context.on.update_status(), state)
+            with open(tempdir + "/certificate.pem") as f:
+                saved_cert = f.read()
+                assert saved_cert == str(certificate)
+
+    @patch(f"{TLS_LIB_PATH}.TLSCertificatesRequiresV4.get_assigned_certificate")
+    def test_given_new_certificate_available_and_new_cert_already_saved_when_configure_then_certificate_not_replaced(
+        self, mock_assigned_certificates, context
+    ):
+        with tempfile.TemporaryDirectory() as tempdir:
+            config_mount = Mount(location="/etc/notary/config", source=tempdir)
+            state = State(
+                storages={Storage(name="config"), Storage(name="database")},
+                containers=[
+                    Container(
+                        name="notary",
+                        can_connect=True,
+                        mounts={"config": config_mount},
+                        layers={
+                            "notary": Layer(
+                                {
+                                    "summary": "notary layer",
+                                    "description": "pebble config layer for notary",
+                                    "services": {
+                                        "notary": {
+                                            "override": "replace",
+                                            "summary": "notary",
+                                            "command": "notary -config /etc/notary/config/config.yaml",
+                                            "startup": "enabled",
+                                        }
+                                    },
+                                }
+                            )
+                        },
+                    )
+                ],
+                relations=[Relation(id=1, endpoint=TLS_ACCESS_RELATION_NAME)],
+                leader=True,
+            )
+            certificate, pk = self.example_cert_and_key()
+            provider_certificate_mock = Mock()
+            provider_certificate_mock.certificate = certificate.raw
+            with open(tempdir + "/certificate.pem", "w") as f:
+                f.write(str(certificate))
+            mock_assigned_certificates.return_value = (provider_certificate_mock, pk)
+            with patch(
+                "notary.Notary.__new__",
+                return_value=Mock(
+                    **{
+                        "is_api_available.return_value": True,
+                        "is_initialized.return_value": True,
+                        "login.return_value": "example-token",
+                        "token_is_valid.return_value": True,
+                    },
+                ),
+            ):
+                context.run(context.on.update_status(), state)
+            with open(tempdir + "/certificate.pem") as f:
+                saved_cert = f.read()
+                assert saved_cert == str(certificate)


### PR DESCRIPTION
# Description

This change introduces the notary tls requires endpoint for certificate providers to provide an access certificate.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
