### PR TITLE
chore: use new notary api

### DIFF
--- a/grafana.lint
+++ b/grafana.lint
@@ -1,2 +1,3 @@
 exclusions:
   template-datasource-rule:
+  target-logql-rule:

--- a/grafana.lint
+++ b/grafana.lint
@@ -1,3 +1,4 @@
 exclusions:
   template-datasource-rule:
   target-logql-rule:
+  target-logql-auto-rule:

--- a/src/charm.py
+++ b/src/charm.py
@@ -224,20 +224,20 @@ class NotaryCharm(ops.CharmBase):
             logger.warning("couldn't distribute certificates: not logged in")
             return
         databag_csrs = self.tls.get_certificate_requests()
-        certificate_requests = self.client.list_certificate_requests(login_details.token)
+        notary_certificate_requests = self.client.list_certificate_requests(login_details.token)
         for request in databag_csrs:
-            certificate_requests_with_matching_csr = [
-                certificate_request
-                for certificate_request in certificate_requests
-                if certificate_request.csr == str(request.certificate_signing_request)
+            notary_certificate_requests_with_matching_csr = [
+                notary_certificate_request
+                for notary_certificate_request in notary_certificate_requests
+                if notary_certificate_request.csr == str(request.certificate_signing_request)
             ]
-            if len(certificate_requests_with_matching_csr) < 1:
+            if len(notary_certificate_requests_with_matching_csr) < 1:
                 self.client.create_certificate_request(
                     str(request.certificate_signing_request), login_details.token
                 )
                 continue
-            assert len(certificate_requests_with_matching_csr) < 2
-            request_notary_entry = certificate_requests_with_matching_csr[0]
+            assert len(notary_certificate_requests_with_matching_csr) < 2
+            request_notary_entry = notary_certificate_requests_with_matching_csr[0]
             certificates_provided_for_csr = [
                 csr
                 for csr in self.tls.get_issued_certificates(request.relation_id)

--- a/src/charm.py
+++ b/src/charm.py
@@ -205,14 +205,15 @@ class NotaryCharm(ops.CharmBase):
         if not login_details:
             return
         if not login_details.token or not self.client.token_is_valid(login_details.token):
-            login_details.token = self.client.login(login_details.username, login_details.password)
-            if not login_details.token:
+            login_response = self.client.login(login_details.username, login_details.password)
+            if not login_response or not login_response.token:
                 logger.warning(
                     "failed to login with the existing admin credentials."
                     " If you've manually modified the admin account credentials,"
                     " please update the charm's credentials secret accordingly."
                 )
                 return
+            login_details.token = login_response.token
             login_details_secret = self.model.get_secret(label=NOTARY_LOGIN_SECRET_LABEL)
             login_details_secret.set_content(login_details.to_dict())
 
@@ -223,22 +224,20 @@ class NotaryCharm(ops.CharmBase):
             logger.warning("couldn't distribute certificates: not logged in")
             return
         databag_csrs = self.tls.get_certificate_requests()
-        notary_table = self.client.get_certificate_requests_table(login_details.token)
-        if not notary_table:
-            logger.warning("couldn't distribute certificates: couldn't get table from notary")
-            return
-
+        certificate_requests = self.client.list_certificate_requests(login_details.token)
         for request in databag_csrs:
-            notary_rows_with_matching_csr = [
-                row
-                for row in notary_table.rows
-                if row.csr == str(request.certificate_signing_request)
+            certificate_requests_with_matching_csr = [
+                certificate_request
+                for certificate_request in certificate_requests
+                if certificate_request.csr == str(request.certificate_signing_request)
             ]
-            if len(notary_rows_with_matching_csr) < 1:
-                self.client.post_csr(str(request.certificate_signing_request), login_details.token)
+            if len(certificate_requests_with_matching_csr) < 1:
+                self.client.create_certificate_request(
+                    str(request.certificate_signing_request), login_details.token
+                )
                 continue
-            assert len(notary_rows_with_matching_csr) < 2
-            request_notary_entry = notary_rows_with_matching_csr[0]
+            assert len(certificate_requests_with_matching_csr) < 2
+            request_notary_entry = certificate_requests_with_matching_csr[0]
             certificates_provided_for_csr = [
                 csr
                 for csr in self.tls.get_issued_certificates(request.relation_id)

--- a/src/notary.py
+++ b/src/notary.py
@@ -3,9 +3,10 @@
 
 """Library for interacting with the Notary application."""
 
+import json
 import logging
-from dataclasses import dataclass
-from typing import Literal
+from dataclasses import asdict, dataclass
+from typing import List, Literal, Optional
 
 import requests
 
@@ -16,6 +17,88 @@ class NotaryClientError(Exception):
     """Base class for exceptions raised by the Notary client."""
 
 
+@dataclass
+class Response:
+    """Response from Notary."""
+
+    result: any  # type: ignore[reportGeneralTypeIssues]
+    error: str
+
+
+@dataclass
+class StatusResponse:
+    """Response from Notary when checking the status."""
+
+    initialized: bool
+    version: str
+
+
+@dataclass
+class LoginParams:
+    """Parameters to login to Notary."""
+
+    username: str
+    password: str
+
+
+@dataclass
+class LoginResponse:
+    """Response from Notary when logging in."""
+
+    token: str
+
+
+@dataclass
+class CreateUserParams:
+    """Parameters to create a user in Notary."""
+
+    username: str
+    password: str
+
+
+@dataclass
+class CreateUserResponse:
+    """Response from Notary when creating a user."""
+
+    id: int
+
+
+@dataclass
+class CreateCertificateRequestParams:
+    """Parameters to create a certificate request in Notary."""
+
+    csr: str
+
+
+@dataclass
+class CreateCertificateRequestResponse:
+    """Response from Notary when creating a certificate request."""
+
+    id: int
+
+
+@dataclass
+class DeleteCertificateRequestResponse:
+    """Response from Notary when deleting a certificate request."""
+
+    id: int
+
+
+@dataclass
+class CreateCertificateParams:
+    """Parameters to create a certificate in Notary."""
+
+    csr: str
+    cert_chain: list[str]
+
+
+@dataclass
+class CreateCertificateResponse:
+    """Response from Notary when creating a certificate."""
+
+    id: int
+
+
 @dataclass(frozen=True)
 class CertificateRequest:
     """The certificate request that's stored in Notary."""
@@ -23,13 +106,6 @@ class CertificateRequest:
     id: int
     csr: str
     certificate_chain: list[str] | Literal["", "rejected"]
-
-
-@dataclass
-class CertificateRequests:
-    """The table of certificate requests in Notary."""
-
-    rows: list[CertificateRequest]
 
 
 class Notary:
@@ -47,173 +123,124 @@ class Notary:
         self.url = url
         self.ca_path = ca_path
 
-    def login(self, username: str, password: str) -> str | None:
-        """Login to notary by sending the username and password and return a Token."""
+    def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        token: Optional[str] = None,
+        data: any = None,  # type: ignore[reportGeneralTypeIssues]
+    ) -> Response | None:
+        """Make an HTTP request and handle common error patterns."""
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        url = f"{self.url}{endpoint}"
         try:
-            req = requests.post(
-                f"{self.url}/login",
+            req = requests.request(
+                method=method,
+                url=url,
                 verify=self.ca_path,
-                json={"username": username, "password": password},
+                headers=headers,
+                json=data,
             )
-        except (requests.RequestException, OSError):
-            logger.warning("login failed: ", exc_info=True)
-            return
+        except requests.RequestException as e:
+            logger.error("HTTP request failed: %s", e)
+            return None
+        except OSError as e:
+            logger.error("couldn't complete HTTP request: %s", e)
+            return None
+
+        response = self._get_result(req)
         try:
             req.raise_for_status()
         except requests.HTTPError:
-            logger.error("couldn't log in: code %s, %s", req.status_code, req.text)
-            return
-        logger.info("logged in to Notary successfully")
-        return req.text
-
-    def token_is_valid(self, token: str) -> bool:
-        """Return if the token is still valid by attempting to connect to an endpoint."""
-        try:
-            req = requests.get(
-                f"{self.url}/api/{self.API_VERSION}/accounts/me",
-                verify=self.ca_path,
-                headers={"Authorization": f"Bearer {token}"},
+            logger.error(
+                "Request failed: code %s, %s",
+                req.status_code,
+                response.error if response else "unknown",
             )
-            req.raise_for_status()
-        except (requests.RequestException, OSError):
-            return False
-        return True
+            return None
+        return response
 
-    def is_api_available(self) -> bool:
-        """Return if the Notary server is reachable."""
+    def _get_result(self, req: requests.Response) -> Response | None:
+        """Return the response from a request."""
         try:
-            req = requests.get(
-                f"{self.url}/status",
-                verify=self.ca_path,
-            )
-            req.raise_for_status()
-        except (requests.RequestException, OSError):
-            return False
-        return True
+            response = req.json()
+        except json.JSONDecodeError:
+            return None
+        return Response(
+            result=response.get("result"),
+            error=response.get("error"),
+        )
 
     def is_initialized(self) -> bool:
         """Return if the Notary server is initialized."""
-        try:
-            req = requests.get(
-                f"{self.url}/status",
-                verify=self.ca_path,
-            )
-            req.raise_for_status()
-        except (requests.RequestException, OSError):
-            return False
-        body = req.json()
-        return body.get("initialized", False)
+        status = self.get_status()
+        return status.initialized if status else False
 
-    def create_first_user(self, username: str, password: str) -> int | None:
-        """Create the first admin user.
+    def is_api_available(self) -> bool:
+        """Return if the Notary server is reachable."""
+        status = self.get_status()
+        return status is not None
 
-        Args:
-            username: username of the first user
-            password: password for the first user. It must be longer than 7 characters, have at least one lowercase,
-                one uppercase and one number or special character.
+    def login(self, username: str, password: str) -> LoginResponse | None:
+        """Login to notary by sending the username and password and return a Token."""
+        login_params = LoginParams(username=username, password=password)
+        response = self._make_request("POST", "/login", data=asdict(login_params))
+        if response and response.result:
+            return LoginResponse(**response.result)
+        return None
 
-        Returns:
-            int | None: the id of the created user, or None if the request failed
+    def token_is_valid(self, token: str) -> bool:
+        """Return if the token is still valid by attempting to connect to an endpoint."""
+        response = self._make_request("GET", f"/api/{self.API_VERSION}/accounts/me", token=token)
+        return response is not None
 
-        """
-        try:
-            req = requests.post(
-                f"{self.url}/api/{self.API_VERSION}/accounts",
-                verify=self.ca_path,
-                json={"username": username, "password": password},
-            )
-        except (requests.RequestException, OSError):
-            return None
-        try:
-            req.raise_for_status()
-        except requests.HTTPError:
-            logger.error("couldn't create first user: code %s, %s", req.status_code, req.text)
-            return None
-        logger.info("created the first user in Notary.")
-        id = req.json().get("id")
-        return int(id) if id else None
+    def get_status(self) -> StatusResponse | None:
+        """Return if the Notary server is initialized."""
+        response = self._make_request("GET", "/status")
+        if response and response.result:
+            return StatusResponse(**response.result)
+        return None
 
-    def get_certificate_requests_table(self, token: str) -> CertificateRequests | None:
-        """Get all certificate requests table from Notary.
-
-        Returns:
-            None if the request fails to go through. The table itself, otherwise.
-        """
-        try:
-            res = requests.get(
-                f"{self.url}/api/{self.API_VERSION}/certificate_requests",
-                verify=self.ca_path,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-            res.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(
-                "couldn't retrieve certificate requests table: code %s, %s",
-                e.response.status_code if e.response else "unknown",
-                e.response.text if e.response else "unknown",
-            )
-            return None
-        except OSError:
-            logger.error("error occurred during HTTP request: TLS file invalid")
-            return None
-        table = res.json()
-        return CertificateRequests(
-            rows=[
-                CertificateRequest(
-                    row.get("id"),
-                    row.get("csr"),
-                    serialize(row.get("certificate")),
-                )
-                for row in table
-            ]
-            if table
-            else []
+    def create_first_user(self, username: str, password: str) -> CreateUserResponse | None:
+        """Create the first admin user."""
+        create_user_params = CreateUserParams(username=username, password=password)
+        response = self._make_request(
+            "POST", f"/api/{self.API_VERSION}/accounts", data=asdict(create_user_params)
         )
+        if response and response.result:
+            return CreateUserResponse(**response.result)
+        return None
 
-    def post_csr(self, csr: str, token: str) -> None:
-        """Post a new CSR to Notary."""
-        try:
-            res = requests.post(
-                f"{self.url}/api/{self.API_VERSION}/certificate_requests",
-                verify=self.ca_path,
-                headers={"Authorization": f"Bearer {token}"},
-                data=csr,
-            )
-            res.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(
-                "couldn't post new certificate requests: code %s, %s",
-                e.response.status_code if e.response else "unknown",
-                e.response.text if e.response else "unknown",
-            )
-        except OSError:
-            logger.error("error occurred during HTTP request: TLS file invalid")
+    def list_certificate_requests(self, token: str) -> List[CertificateRequest]:
+        """Get all certificate requests from Notary."""
+        response = self._make_request(
+            "GET", f"/api/{self.API_VERSION}/certificate_requests", token=token
+        )
+        if response and response.result:
+            return [
+                CertificateRequest(
+                    id=cert.get("id"),
+                    csr=cert.get("csr"),
+                    certificate_chain=serialize(cert.get("certificate")),
+                )
+                for cert in response.result
+            ]
+        return []
 
-    def post_certificate(self, csr: str, cert_chain: list[str], token: str) -> None:
-        """Post a certificate chain to an associated csr to Notary."""
-        try:
-            table = self.get_certificate_requests_table(token)
-            if not table:
-                return
-            csr_ids = list(filter(lambda x: x.csr == csr, table.rows))
-            if len(csr_ids) != 1:
-                logger.error("given CSR not found in Notary")
-                return
-            res = requests.post(
-                f"{self.url}/api/{self.API_VERSION}/certificate_requests/{csr_ids[0].id}/certificate",
-                verify=self.ca_path,
-                headers={"Authorization": f"Bearer {token}"},
-                data="\n".join(cert_chain),
-            )
-            res.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(
-                "couldn't post new certificate: code %s, %s",
-                e.response.status_code if e.response else "unknown",
-                e.response.text if e.response else "unknown",
-            )
-        except OSError:
-            logger.error("error occurred during HTTP request: TLS file invalid")
+    def create_certificate_request(
+        self, csr: str, token: str
+    ) -> CreateCertificateRequestResponse | None:
+        """Create a new certificate request in Notary."""
+        create_certificate_request_params = CreateCertificateRequestParams(csr=csr)
+        response = self._make_request(
+            "POST",
+            f"/api/{self.API_VERSION}/certificate_requests",
+            token=token,
+            data=asdict(create_certificate_request_params),
+        )
+        if response and response.result:
+            return CreateCertificateRequestResponse(**response.result)
+        return None
 
 
 def serialize(pem_string: str) -> list[str] | Literal["", "rejected"]:

--- a/src/notary.py
+++ b/src/notary.py
@@ -250,10 +250,10 @@ class Notary:
             )
         return None
 
-    def create_certificate(
+    def create_certificate_from_csr(
         self, csr: str, cert_chain: list[str], token: str
     ) -> CreateCertificateResponse | None:
-        """Create a new certificate in Notary."""
+        """Create a certificate from a CSR in Notary."""
         certificate_requests = self.list_certificate_requests(token=token)
         if not certificate_requests:
             logger.error("couldn't list certificate requests")

--- a/src/notary.py
+++ b/src/notary.py
@@ -186,7 +186,9 @@ class Notary:
         login_params = LoginParams(username=username, password=password)
         response = self._make_request("POST", "/login", data=asdict(login_params))
         if response and response.result:
-            return LoginResponse(**response.result)
+            return LoginResponse(
+                token=response.result.get("token"),
+            )
         return None
 
     def token_is_valid(self, token: str) -> bool:
@@ -198,7 +200,10 @@ class Notary:
         """Return if the Notary server is initialized."""
         response = self._make_request("GET", "/status")
         if response and response.result:
-            return StatusResponse(**response.result)
+            return StatusResponse(
+                initialized=response.result.get("initialized"),
+                version=response.result.get("version"),
+            )
         return None
 
     def create_first_user(self, username: str, password: str) -> CreateUserResponse | None:
@@ -208,7 +213,9 @@ class Notary:
             "POST", f"/api/{self.API_VERSION}/accounts", data=asdict(create_user_params)
         )
         if response and response.result:
-            return CreateUserResponse(**response.result)
+            return CreateUserResponse(
+                id=response.result.get("id"),
+            )
         return None
 
     def list_certificate_requests(self, token: str) -> List[CertificateRequest]:
@@ -239,7 +246,9 @@ class Notary:
             data=asdict(create_certificate_request_params),
         )
         if response and response.result:
-            return CreateCertificateRequestResponse(**response.result)
+            return CreateCertificateRequestResponse(
+                id=response.result.get("id"),
+            )
         return None
 
     def create_certificate(
@@ -262,7 +271,9 @@ class Notary:
             data=asdict(create_certificate_params),
         )
         if response and response.result:
-            return CreateCertificateResponse(**response.result)
+            return CreateCertificateResponse(
+                id=response.result.get("id"),
+            )
         return None
 
 

--- a/src/notary.py
+++ b/src/notary.py
@@ -88,8 +88,7 @@ class DeleteCertificateRequestResponse:
 class CreateCertificateParams:
     """Parameters to create a certificate in Notary."""
 
-    csr: str
-    cert_chain: list[str]
+    certificate: str
 
 
 @dataclass
@@ -263,7 +262,7 @@ class Notary:
         if len(csr_ids) != 1:
             logger.error("given CSR not found in Notary")
             return None
-        create_certificate_params = CreateCertificateParams(csr=csr, cert_chain=cert_chain)
+        create_certificate_params = CreateCertificateParams(certificate="\n".join(cert_chain))
         response = self._make_request(
             "POST",
             f"/api/{self.API_VERSION}/certificate_requests/{csr_ids[0].id}/certificate",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -145,7 +145,7 @@ async def test_given_notary_when_tls_requirer_related_then_csr_uploaded_to_notar
     ca = generate_ca(ca_pk, 365, "integration-test")
     cert = generate_certificate(CertificateSigningRequest.from_string(row.csr), ca, ca_pk, 365)
     chain = [str(cert), str(ca)]
-    client.post_certificate(row.csr, chain, token)
+    client.create_certificate(row.csr, chain, token)
 
     table = client.list_certificate_requests(token)
     assert table

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -136,21 +136,21 @@ async def test_given_notary_when_tls_requirer_related_then_csr_uploaded_to_notar
         timeout=1000,
         raise_on_error=True,
     )
-    table = client.list_certificate_requests(token)
-    assert table
-    assert len(table.rows) == 1
+    certificate_requests = client.list_certificate_requests(token)
+    assert len(certificate_requests) == 1
 
-    row = table.rows[0]
+    certificate_request = certificate_requests[0]
     ca_pk = generate_private_key()
     ca = generate_ca(ca_pk, 365, "integration-test")
-    cert = generate_certificate(CertificateSigningRequest.from_string(row.csr), ca, ca_pk, 365)
+    cert = generate_certificate(
+        CertificateSigningRequest.from_string(certificate_request.csr), ca, ca_pk, 365
+    )
     chain = [str(cert), str(ca)]
-    client.create_certificate(row.csr, chain, token)
+    client.create_certificate(certificate_request.csr, chain, token)
 
-    table = client.list_certificate_requests(token)
-    assert table
-    assert table.rows[0].certificate_chain != ""
-    assert table.rows[0].certificate_chain != "rejected"
+    certificate_requests = client.list_certificate_requests(token)
+    assert certificate_requests[0].certificate_chain != ""
+    assert certificate_requests[0].certificate_chain != "rejected"
 
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, TLS_REQUIRER_APPLICATION_NAME],

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -136,7 +136,7 @@ async def test_given_notary_when_tls_requirer_related_then_csr_uploaded_to_notar
         timeout=1000,
         raise_on_error=True,
     )
-    table = client.get_certificate_requests_table(token)
+    table = client.list_certificate_requests(token)
     assert table
     assert len(table.rows) == 1
 
@@ -147,7 +147,7 @@ async def test_given_notary_when_tls_requirer_related_then_csr_uploaded_to_notar
     chain = [str(cert), str(ca)]
     client.post_certificate(row.csr, chain, token)
 
-    table = client.get_certificate_requests_table(token)
+    table = client.list_certificate_requests(token)
     assert table
     assert table.rows[0].certificate_chain != ""
     assert table.rows[0].certificate_chain != "rejected"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -144,7 +144,7 @@ async def test_given_notary_when_tls_requirer_related_then_csr_uploaded_to_notar
         CertificateSigningRequest.from_string(certificate_request.csr), ca, ca_pk, 365
     )
     chain = [str(cert), str(ca)]
-    client.create_certificate(certificate_request.csr, chain, token)
+    client.create_certificate_from_csr(certificate_request.csr, chain, token)
 
     certificate_requests = client.list_certificate_requests(token)
     assert certificate_requests[0].certificate_chain != ""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -49,13 +49,11 @@ async def test_build_and_deploy(ops_test: OpsTest, request: pytest.FixtureReques
         "self-signed-certificates",
         application_name=TLS_PROVIDER_APPLICATION_NAME,
         channel="edge",
-        trust=True,
     )
     await ops_test.model.deploy(
         "tls-certificates-requirer",
         application_name=TLS_REQUIRER_APPLICATION_NAME,
         channel="edge",
-        trust=True,
     )
     await ops_test.model.deploy(
         "prometheus-k8s",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,8 +25,8 @@ from lib.charms.tls_certificates_interface.v4.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from notary import CertificateRequest as CertificateRequestRow
-from notary import CertificateRequests
+from notary import CertificateRequest as CertificateRequestEntry
+from notary import LoginResponse
 
 TLS_LIB_PATH = "charms.tls_certificates_interface.v4.tls_certificates"
 
@@ -2999,7 +2999,7 @@ class TestCharm:
                 **{
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": False,
-                    "login.return_value": "example-token",
+                    "login.return_value": LoginResponse(token="example-token"),
                     "token_is_valid.return_value": False,
                 },
             ),
@@ -3047,7 +3047,7 @@ class TestCharm:
                 **{
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": False,
-                    "login.return_value": "example-token",
+                    "login.return_value": LoginResponse(token="example-token"),
                     "token_is_valid.return_value": False,
                 },
             ),
@@ -3109,8 +3109,8 @@ class TestCharm:
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
                     "token_is_valid.return_value": True,
-                    "get_certificate_requests_table.return_value": CertificateRequests(rows=[]),
-                    "post_csr": post_call,
+                    "list_certificate_requests.return_value": [],
+                    "create_certificate_request": post_call,
                 },
             ),
         ):
@@ -3173,9 +3173,9 @@ class TestCharm:
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
                     "token_is_valid.return_value": True,
-                    "get_certificate_requests_table.return_value": CertificateRequests(
-                        rows=[CertificateRequestRow(id=1, csr=str(csr), certificate_chain="")]
-                    ),
+                    "list_certificate_requests.return_value": [
+                        CertificateRequestEntry(id=1, csr=str(csr), certificate_chain="")
+                    ],
                     "post_csr": post_call,
                 },
             ),
@@ -3242,13 +3242,11 @@ class TestCharm:
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
                     "token_is_valid.return_value": True,
-                    "get_certificate_requests_table.return_value": CertificateRequests(
-                        rows=[
-                            CertificateRequestRow(
-                                id=1, csr=str(csr), certificate_chain=[str(cert), str(ca)]
-                            )
-                        ]
-                    ),
+                    "list_certificate_requests.return_value": [
+                        CertificateRequestEntry(
+                            id=1, csr=str(csr), certificate_chain=[str(cert), str(ca)]
+                        )
+                    ],
                 },
             ),
         ):
@@ -3328,13 +3326,11 @@ class TestCharm:
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
                     "token_is_valid.return_value": True,
-                    "get_certificate_requests_table.return_value": CertificateRequests(
-                        rows=[
-                            CertificateRequestRow(
-                                id=1, csr=str(csr), certificate_chain=[str(new_cert), str(ca)]
-                            )
-                        ]
-                    ),
+                    "list_certificate_requests.return_value": [
+                        CertificateRequestEntry(
+                            id=1, csr=str(csr), certificate_chain=[str(new_cert), str(ca)]
+                        )
+                    ],
                 },
             ),
         ):
@@ -3413,11 +3409,9 @@ class TestCharm:
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
                     "token_is_valid.return_value": True,
-                    "get_certificate_requests_table.return_value": CertificateRequests(
-                        rows=[
-                            CertificateRequestRow(id=1, csr=str(csr), certificate_chain="rejected")
-                        ]
-                    ),
+                    "list_certificate_requests.return_value": [
+                        CertificateRequestEntry(id=1, csr=str(csr), certificate_chain="rejected")
+                    ],
                 },
             ),
         ):
@@ -3467,7 +3461,7 @@ class TestCharm:
                 **{
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
-                    "login.return_value": "example-token",
+                    "login.return_value": LoginResponse(token="example-token"),
                     "token_is_valid.return_value": True,
                 },
             ),
@@ -3524,7 +3518,7 @@ class TestCharm:
                 **{
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
-                    "login.return_value": "example-token",
+                    "login.return_value": LoginResponse(token="example-token"),
                     "token_is_valid.return_value": True,
                 },
             ),
@@ -3579,7 +3573,7 @@ class TestCharm:
                 **{
                     "is_api_available.return_value": True,
                     "is_initialized.return_value": True,
-                    "login.return_value": "example-token",
+                    "login.return_value": LoginResponse(token="example-token"),
                     "token_is_valid.return_value": True,
                 },
             ),


### PR DESCRIPTION
# Description

Here we adapt the Notary K8s charm the the new Notary API. Doing so, we centralize the request creation and parsing using the new `_make_request` function.

We also improve some struct and function names for standardization. For example:
- `get_certificate_requests_table` -> `list_certificate_requests`
- `post_csr` -> `create_certificate_request`

## Why I added Grafana lint exclusions

The CI is now failing at the grafana lint stage for a reason unrelated to my change. The [grafana dashboard linter](https://github.com/grafana/dashboard-linter) recently added logql linting. They don't version the tool and we use the `latest` version, hence why our CI was passing and is now failing on Grafana lint.

I added the following two Grafana lint exclusions:
- target-logql-rule:
- target-logql-auto-rule:

We should likely address those in the future.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
