### PR TITLE
feat: set juju workload version using Notary's API

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -139,6 +139,7 @@ class NotaryCharm(ops.CharmBase):
         self._configure_access_certificates()
         self._configure_charm_authorization()
         self._configure_certificate_requirers()
+        self._configure_juju_workload_version()
 
     def _on_collect_status(self, event: ops.CollectStatusEvent):
         if not self.unit.is_leader():
@@ -281,6 +282,15 @@ class NotaryCharm(ops.CharmBase):
                         chain=certificate_chain,
                     )
                 )
+
+    def _configure_juju_workload_version(self):
+        """Set the Juju workload version to the Notary version."""
+        if not self.unit.is_leader():
+            return
+        if not self.client.is_api_available():
+            return
+        if version := self.client.get_version():
+            self.unit.set_workload_version(version)
 
     ## Properties ##
     @property

--- a/src/notary.py
+++ b/src/notary.py
@@ -180,6 +180,11 @@ class Notary:
         status = self.get_status()
         return status is not None
 
+    def get_version(self) -> str | None:
+        """Return the version of the Notary server."""
+        status = self.get_status()
+        return status.version if status else None
+
     def login(self, username: str, password: str) -> LoginResponse | None:
         """Login to notary by sending the username and password and return a Token."""
         login_params = LoginParams(username=username, password=password)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2998,7 +2998,7 @@ class TestCharm:
             return_value=Mock(
                 **{
                     "is_api_available.return_value": True,
-                    "get_status.returl_value": StatusResponse(version="1.2.3"),
+                    "get_status.return_value": StatusResponse(version="1.2.3"),
                 },
             ),
         ):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,7 +26,7 @@ from lib.charms.tls_certificates_interface.v4.tls_certificates import (
     generate_private_key,
 )
 from notary import CertificateRequest as CertificateRequestEntry
-from notary import LoginResponse, StatusResponse
+from notary import LoginResponse
 
 TLS_LIB_PATH = "charms.tls_certificates_interface.v4.tls_certificates"
 
@@ -2998,7 +2998,8 @@ class TestCharm:
             return_value=Mock(
                 **{
                     "is_api_available.return_value": True,
-                    "get_status.return_value": StatusResponse(version="1.2.3"),
+                    "login.return_value": None,
+                    "get_version.return_value": "1.2.3",
                 },
             ),
         ):


### PR DESCRIPTION
# Description

Here we set the Juju workload version using Notary's API. This allows users to know which version of Notary they are effectively installing. 

## Reference
- https://juju.is/docs/sdk/set-the-workload-version

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
