### PR TITLE
chore: publish charm to track 0 instead of latest

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,43 @@
+name: Promote Charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      promotion:
+        type: choice
+        description: Channel to promote from
+        options:
+          - edge -> beta
+          - beta -> candidate
+          - candidate -> stable
+
+jobs:
+  promote:
+    name: Promote Charm
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set target channel
+        env:
+          PROMOTE_FROM: ${{ github.event.inputs.promotion }}
+        run: |
+          if [ "${PROMOTE_FROM}" == "edge -> beta" ]; then
+            echo "promote-from=edge" >> ${GITHUB_ENV}
+            echo "promote-to=beta" >> ${GITHUB_ENV}
+          elif [ "${PROMOTE_FROM}" == "beta -> candidate" ]; then
+            echo "promote-from=beta" >> ${GITHUB_ENV}
+            echo "promote-to=candidate" >> ${GITHUB_ENV}
+          elif [ "${PROMOTE_FROM}" == "candidate -> stable" ]; then
+            echo "promote-from=candidate" >> ${GITHUB_ENV}
+            echo "promote-to=stable" >> ${GITHUB_ENV}
+          fi
+      - name: Promote Charm
+        uses: canonical/charming-actions/release-charm@2.6.3
+        with:
+          base-channel: 22.04
+          credentials: ${{ secrets.CHARMCRAFT_AUTH }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          destination-channel: 0/${{ env.promote-to }}
+          origin-channel: 0/${{ env.promote-from }}
+          charmcraft-channel: latest/stable

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -37,7 +37,7 @@ jobs:
           built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: latest/edge
+          channel: 0/edge
 
       - name: Archive charmcraft logs
         if: failure()


### PR DESCRIPTION
# Description

Here, we publish the Notary K8s charm to track `0` instead of `latest`.

The track was just created in Charmhub

![image](https://github.com/user-attachments/assets/279922c8-339b-4c38-b6ed-4c7c2d84bd37)

We also have a guardrail allowing us to create any track that match with the `\\d+` regex. Reference:
- https://discourse.charmhub.io/t/a-new-0-track-for-notary-k8s/15756/4

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
