### PR TITLE
fix: promote using 24.04 base channel

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Promote Charm
         uses: canonical/charming-actions/release-charm@2.6.3
         with:
-          base-channel: 22.04
+          base-channel: 24.04
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: 0/${{ env.promote-to }}


### PR DESCRIPTION
# Description

Promote using 24.04 base channel. There is currently a bug with the promote action:

## Logs
```
Error: No channel with base name ubuntu, base channel 22.04 and base architecture amd64
Error: Error: No channel with base name ubuntu, base channel 22.04 and base architecture amd64
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
