### PR TITLE
fix: Fix skipped integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ test = [
     "juju",
     "pytest",
     "pytest-operator",
-    "pytest-asyncio==0.25.3",
+    "pytest-asyncio==0.21.2",
     "ops[testing]",
 ]
 dev = [

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ tests_path = {tox_root}/tests
 all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
+runner = uv-venv-lock-runner
+with_dev = true
 set_env =
     PYTHONPATH = {tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=pdb.set_trace

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ test = [
     { name = "juju" },
     { name = "ops", extras = ["testing"] },
     { name = "pytest" },
-    { name = "pytest-asyncio", specifier = "==0.25.3" },
+    { name = "pytest-asyncio", specifier = "==0.21.2" },
     { name = "pytest-operator" },
 ]
 
@@ -1203,14 +1203,14 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.25.3"
+version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/53/57663d99acaac2fcdafdc697e52a9b1b7d6fcf36616281ff9768a44e7ff3/pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45", size = 30656 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
+    { url = "https://files.pythonhosted.org/packages/9c/ce/1e4b53c213dce25d6e8b163697fbce2d43799d76fa08eea6ad270451c370/pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b", size = 13368 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

The integration tests were being skipped because of `pytest-asyncio`. This change ensures that locked dependencies are used, which should ensure the tests run.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
