### PR TITLE
fix: Disable integration tests on ARM

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,8 +10,9 @@ jobs:
         arch:
           - arch: amd64
             runner: [self-hosted, linux, X64, jammy, xlarge]
-          - arch: arm64
-            runner: [self-hosted, linux, ARM64, jammy, medium]
+          # Disabling until Notary and the charm are released
+          # - arch: arm64
+          #   runner: [self-hosted, linux, ARM64, jammy, medium]
 
     runs-on: ${{ matrix.arch.runner }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
-    uses: canonical/identity-credentials-workflows/.github/workflows/build-charm-multiarch.yaml@v0
+    uses: canonical/identity-credentials-workflows/.github/workflows/build-charm.yaml@v0
 
   integration-test:
     needs:
@@ -43,7 +43,7 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@v0
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v0
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
     with:


### PR DESCRIPTION
# Description

The self hosted arm runners are currently failing to setup strictly confined microk8s because of HWE Kernel.
Running the tests on ARM for Notary at the moment is not necessary anyway and it uses runner hours. 
The tests are disabled on ARM until Notary and its charm are released.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
