### PR TITLE
fix: Set artifact name to publish charm correctly

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,3 +48,4 @@ jobs:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
     with:
       track-name: 0
+      artifact-name: built-charm-amd64


### PR DESCRIPTION
# Description

The change in the charmcraft.yaml syntax leads to a change in the artifact name, this passes the correct name to the workflow.
Once ARM is enabled again we should use the multiarch shared workflow instead.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
